### PR TITLE
Add an automatic https option

### DIFF
--- a/YAFD/Configuration.cs
+++ b/YAFD/Configuration.cs
@@ -16,7 +16,13 @@ namespace YetAnotherFaviconDownloader
         /// </summary>
         private const string automaticPrefixURLs = pluginName + "PrefixURLs";
         private bool? m_automaticPrefixURLs = null;
-
+		
+        /// <summary>
+        /// Automatic prefix URLs with https:// setting
+        /// </summary>
+        private const string automaticHttpsPrefixURLs = pluginName + "HttpsPrefixURLs";
+        private bool? m_automaticHttpsPrefixURLs = null;		
+		
         /// <summary>
         /// Use title field if URL field is empty setting
         /// </summary>
@@ -42,6 +48,22 @@ namespace YetAnotherFaviconDownloader
         {
             m_automaticPrefixURLs = value;
             config.SetBool(automaticPrefixURLs, value);
+        }
+		
+		public bool GetAutomaticHttpsPrefixURLs()
+        {
+            if (!m_automaticHttpsPrefixURLs.HasValue)
+            {
+                m_automaticHttpsPrefixURLs = config.GetBool(automaticHttpsPrefixURLs, false);
+            }
+
+            return m_automaticHttpsPrefixURLs.Value;
+        }
+
+        public void SetAutomaticHttpsPrefixURLs(bool value)
+        {
+            m_automaticHttpsPrefixURLs = value;
+            config.SetBool(automaticHttpsPrefixURLs, value);
         }
 
         public bool GetUseTitleField()

--- a/YAFD/FaviconDownloader.cs
+++ b/YAFD/FaviconDownloader.cs
@@ -201,14 +201,24 @@ namespace YetAnotherFaviconDownloader
         {
             if (!httpSchema.IsMatch(url))
             {
-                // If the user doesn't want to add the prefix, there is nothing I can do about
-                if (!YetAnotherFaviconDownloaderExt.Config.GetAutomaticPrefixURLs())
+                // The given url needs to be patched
+                if (!YetAnotherFaviconDownloaderExt.Config.GetAutomaticPrefixURLs() && 
+					!YetAnotherFaviconDownloaderExt.Config.GetAutomaticHttpsPrefixURLs())
                 {
+					// If the user doesn't want to add the prefix, there is nothing I can do about
                     return false;
                 }
+				else if (YetAnotherFaviconDownloaderExt.Config.GetAutomaticPrefixURLs())
+				{   
+					// Prefix the URL with a valid http schema
+					url = "http://" + url;
+				}
+				else if (YetAnotherFaviconDownloaderExt.Config.GetAutomaticHttpsPrefixURLs())
+				{   
+					// Prefix the URL with a valid http schema
+					url = "https://" + url;
+				}
 
-                // Prefix the URL with a valid schema
-                url = "http://" + url;
             }
 
             // TODO: this still can be improved to test https://

--- a/YAFD/YetAnotherFaviconDownloaderExt.cs
+++ b/YAFD/YetAnotherFaviconDownloaderExt.cs
@@ -95,6 +95,10 @@ namespace YetAnotherFaviconDownloader
             // Automatic prefix URLs with http://
             toolsSubItemsPrefixURLsItem = new ToolStripMenuItem("Automatic prefix URLs with http://", null, PrefixURLsMenu_Click);  // TODO: i18n?
             toolsSubItemsPrefixURLsItem.Checked = Config.GetAutomaticPrefixURLs();
+            
+            // Automatic prefix URLs with https://
+            toolsSubItemsHttpsPrefixURLsItem = new ToolStripMenuItem("Automatic prefix URLs with https://", null, HttpsPrefixURLsMenu_Click);  // TODO: i18n?
+            toolsSubItemsHttpsPrefixURLsItem.Checked = Config.GetAutomaticHttpsPrefixURLs();            
 
             // Use title field if URL field is empty
             toolsSubItemsTitleFieldItem = new ToolStripMenuItem("Use title field if URL field is empty", null, TitleFieldMenu_Click);  // TODO: i18n?
@@ -192,6 +196,15 @@ namespace YetAnotherFaviconDownloader
 
             Config.SetAutomaticPrefixURLs(menu.Checked);
         }
+        
+        private void HttpsPrefixURLsMenu_Click(object sender, EventArgs e)
+        {
+            ToolStripMenuItem menu = sender as ToolStripMenuItem;
+
+            menu.Checked = !menu.Checked;
+
+            Config.SetAutomatiHtppsPrefixURLs(menu.Checked);
+        }        
 
         private void TitleFieldMenu_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
Discoverd your plugin today. Missed an option to automatically prefix urls with the https:// tags. Might be useful at pages who don't allow unsecure http connections and have disabled automatic redirect to https. If I understood your code correct, this patch is just a cosmectic thing and might not improve security (see line below).
https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/blob/aa57b95e27e614c20917ae41e663adeabcfa2580/YAFD/FaviconDownloader.cs#L58

This is just quick and dirty and I didn't had the time nor the knowledge to test it so: This pull request needs testing :)