### PR TITLE
Add an option to add/update icons to entries without changing last modified

### DIFF
--- a/YAFD/Configuration.cs
+++ b/YAFD/Configuration.cs
@@ -23,6 +23,12 @@ namespace YetAnotherFaviconDownloader
         private const string useTitleField = pluginName + "TitleField";
         private bool? m_useTitleField = null;
 
+        /// <summary>
+        /// Update last modified date when adding/updating icons
+        /// </summary>
+        private const string updateLastModified = pluginName + "UpdateLastModified";
+        private bool? m_updateLastModified = null;
+
         public Configuration(AceCustomConfig aceCustomConfig)
         {
             config = aceCustomConfig;
@@ -58,6 +64,22 @@ namespace YetAnotherFaviconDownloader
         {
             m_useTitleField = value;
             config.SetBool(useTitleField, value);
+        }
+
+        public bool GetUpdateLastModified()
+        {
+            if (!m_updateLastModified.HasValue)
+            {
+                m_updateLastModified = config.GetBool(updateLastModified, true);
+            }
+
+            return m_updateLastModified.Value;
+        }
+
+        public void SetUpdateLastModified(bool value)
+        {
+            m_updateLastModified = value;
+            config.SetBool(updateLastModified, value);
         }
     }
 }

--- a/YAFD/FaviconDialog.cs
+++ b/YAFD/FaviconDialog.cs
@@ -268,7 +268,8 @@ namespace YetAnotherFaviconDownloader
                 if (entry == null) continue;
 
                 // Save it
-                entry.Touch(true, false);
+                entry.Touch(YetAnotherFaviconDownloaderExt.Config.GetUpdateLastModified(), false);
+                
             }
 
             // Unblock UI

--- a/YAFD/YetAnotherFaviconDownloaderExt.cs
+++ b/YAFD/YetAnotherFaviconDownloaderExt.cs
@@ -55,6 +55,7 @@ namespace YetAnotherFaviconDownloader
         // YAFD SubItems
         private ToolStripMenuItem toolsSubItemsPrefixURLsItem;
         private ToolStripMenuItem toolsSubItemsTitleFieldItem;
+        private ToolStripMenuItem toolsSubItemsUpdateModifiedItem;
 
         public override bool Initialize(IPluginHost host)
         {
@@ -100,6 +101,10 @@ namespace YetAnotherFaviconDownloader
             toolsSubItemsTitleFieldItem = new ToolStripMenuItem("Use title field if URL field is empty", null, TitleFieldMenu_Click);  // TODO: i18n?
             toolsSubItemsTitleFieldItem.Checked = Config.GetUseTitleField();
 
+            // Update last modified date when adding/updating icons
+            toolsSubItemsUpdateModifiedItem = new ToolStripMenuItem("Update entry's last modification time when adding/updating icons", null, LastModifiedMenu_Click);  // TODO: i18n?
+            toolsSubItemsUpdateModifiedItem.Checked = Config.GetUpdateLastModified();
+
             // Add Tools menu items
             toolsMenuSeparator = new ToolStripSeparator();
 
@@ -107,6 +112,7 @@ namespace YetAnotherFaviconDownloader
             {
                 toolsSubItemsPrefixURLsItem,
                 toolsSubItemsTitleFieldItem,
+                toolsSubItemsUpdateModifiedItem,
 #if DEBUG
                 new ToolStripMenuItem("Reset Icons", null, ResetIconsMenu_Click)
 #endif
@@ -200,6 +206,14 @@ namespace YetAnotherFaviconDownloader
             menu.Checked = !menu.Checked;
 
             Config.SetUseTitleField(menu.Checked);
+        }
+        private void LastModifiedMenu_Click(object sender, EventArgs e)
+        {
+            ToolStripMenuItem menu = sender as ToolStripMenuItem;
+
+            menu.Checked = !menu.Checked;
+
+            Config.SetUpdateLastModified(menu.Checked);
         }
 
 #if DEBUG


### PR DESCRIPTION
Applying this adds a menu item and supporting configuration for the option to enable/disable
update of last modification time during entry modification. The default
configuration is to update the last modification time.

I tested it out on windows and have been using it without issue for a few days. Feel free to look it over and accept it, reject it, or change it, but I figured there are probably other people that might have a similar problem and figured I would try to contribute back in case you wanted it.

**Why?:** I find your icon downloader addon much nicer than a different one I used but I missed being able to get an icon without changing the entry last modified date. I use the last modified of entries to keep track of the last time i changed a password or the entry, so I needed a way to get all the icons for the entries in my database without ending up with an entire database of entries that had today's date as last modified just because they had an icon added to them. This is the solution I came up with. I'm sure some people find the last time the icon on their password entry was added or updated relevant, but to me it doesn't matter and makes the last modified column unhelpful for my personal purposes. 

**Edit:** Screenshot with the extra menu option shown below. If you do end up including this I would probably rename that option, it's a bit wordy and long right now.

![favicon](https://user-images.githubusercontent.com/5547080/75722892-f93fad00-5c8f-11ea-8a90-2aeed14b2459.png)