### PR TITLE
Fixes

### DIFF
--- a/Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("ce5bbe79-0165-4fc5-a953-36f6a8e93c8e")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests</RootNamespace>
+    <AssemblyName>Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YAFD\YetAnotherFaviconDownloader.csproj">
+      <Project>{d336cd55-d045-4d90-8398-59f0a7d419bb}</Project>
+      <Name>YetAnotherFaviconDownloader</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using YetAnotherFaviconDownloader;
+
+namespace Tests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            //            var url = "https://www.asnbank.nl/home.html";
+            var url = "https://mijn.ing.nl/internetbankieren/SesamLoginServlet"; // "https://www.asnbank.nl/onlinebankieren/secure/loginparticulier.html";
+            using (FaviconDownloader fd = new FaviconDownloader())
+            {
+                // Download favicon
+                byte[] data = fd.GetIcon(url);
+                Assert.IsNotNull(data);
+            }
+        }
+    }
+
+}

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net45" />
+</packages>

--- a/YAFD/FaviconDownloader.cs
+++ b/YAFD/FaviconDownloader.cs
@@ -98,6 +98,18 @@ namespace YetAnotherFaviconDownloader
                         // ignore the exception and try the next resource
                     }
                 }
+                // no valid image found, inspect the URL if it has a path and or query the problem might be that
+                // we are retrieving a login page instead of the initial landing page.
+                // Lets try just without a path or query
+                if (!string.IsNullOrEmpty(address.PathAndQuery))
+                {
+                    var new_url = address.GetLeftPart(UriPartial.Authority) + "/";
+                    if (new_url != url)
+                    { 
+                        url = new_url;
+                        goto retry_http;
+                    }
+                }
             }
             catch (WebException ex)
             {

--- a/YAFD/FaviconDownloader.cs
+++ b/YAFD/FaviconDownloader.cs
@@ -24,6 +24,8 @@ namespace YetAnotherFaviconDownloader
 
         // URI after redirection
         private Uri responseUri;
+        private CookieContainer cookieContainer;
+
 
         static FaviconDownloader()
         {
@@ -60,6 +62,7 @@ namespace YetAnotherFaviconDownloader
 
         public byte[] GetIcon(string url)
         {
+            cookieContainer = new CookieContainer();
             // We prefer https first (just to preserve the original link)
             string origURL = url;
 
@@ -158,7 +161,7 @@ namespace YetAnotherFaviconDownloader
             request.MaximumAutomaticRedirections = 10;
 
             // Sets the cookies associated with the request (security issue?)
-            request.CookieContainer = new CookieContainer();
+            request.CookieContainer = cookieContainer;
 
             // Sets a fake user agent
             request.UserAgent = userAgent;

--- a/YAFD/YetAnotherFaviconDownloader.csproj
+++ b/YAFD/YetAnotherFaviconDownloader.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="KeePass">
-      <HintPath>C:\Program Files (x86)\KeePass Password Safe 2\KeePass.exe</HintPath>
+      <HintPath>..\..\..\keepass\KeePass.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/YetAnotherFaviconDownloader.sln
+++ b/YetAnotherFaviconDownloader.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YetAnotherFaviconDownloader", "YAFD\YetAnotherFaviconDownloader.csproj", "{D336CD55-D045-4D90-8398-59F0A7D419BB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{D336CD55-D045-4D90-8398-59F0A7D419BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D336CD55-D045-4D90-8398-59F0A7D419BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D336CD55-D045-4D90-8398-59F0A7D419BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE5BBE79-0165-4FC5-A953-36F6A8E93C8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Resolves two reasons why downloading of the favicon might fail. The login page does not provide a favicon while the homepage of the website does. The favicon can only be downloaded when the cookie set by the page is present.