### PR TITLE
Option to use Google S2 API for fetching icon 

### DIFF
--- a/YAFD/Configuration.cs
+++ b/YAFD/Configuration.cs
@@ -29,6 +29,12 @@ namespace YetAnotherFaviconDownloader
         private const string updateLastModified = pluginName + "UpdateLastModified";
         private bool? m_updateLastModified = null;
 
+        /// <summary>
+        /// Use Google S2 API to fetch 16x16 icons
+        /// </summary>
+        private const string useGoogleAPI = pluginName + "UseGoogleAPI";
+        private bool? m_useGoogleAPI = null;
+
         public Configuration(AceCustomConfig aceCustomConfig)
         {
             config = aceCustomConfig;
@@ -80,6 +86,22 @@ namespace YetAnotherFaviconDownloader
         {
             m_updateLastModified = value;
             config.SetBool(updateLastModified, value);
+        }
+
+        public bool GetUseGoogleAPI()
+        {
+            if (!m_useGoogleAPI.HasValue)
+            {
+                m_useGoogleAPI = config.GetBool(useGoogleAPI, true);
+            }
+
+            return m_useGoogleAPI.Value;
+        }
+
+        public void SetUseGoogleAPI(bool value)
+        {
+            m_useGoogleAPI = value;
+            config.SetBool(useGoogleAPI, value);
         }
     }
 }

--- a/YAFD/FaviconDownloader.cs
+++ b/YAFD/FaviconDownloader.cs
@@ -69,6 +69,23 @@ namespace YetAnotherFaviconDownloader
                 throw new FaviconDownloaderException(FaviconDownloaderExceptionStatus.NotFound);
             }
 
+            if (YetAnotherFaviconDownloaderExt.Config.GetUseGoogleAPI()) {
+                Uri address = new Uri("https://www.google.com/s2/favicons?domain_url=" + new Uri(url).Host);
+
+                try {
+                    // Download file
+                    byte[] data = DownloadAsset(address);
+
+                    // Check if the data is a valid image
+                    if (IsValidImage(data)) {
+                        return data;
+                    }
+                } catch (WebException) {
+                    // ignore the exception and try the regular method
+                    // throw new FaviconDownloaderException(FaviconDownloaderExceptionStatus.NotFound);
+                }
+            }
+
         retry_http:
             try
             {

--- a/YAFD/YetAnotherFaviconDownloaderExt.cs
+++ b/YAFD/YetAnotherFaviconDownloaderExt.cs
@@ -56,6 +56,7 @@ namespace YetAnotherFaviconDownloader
         private ToolStripMenuItem toolsSubItemsPrefixURLsItem;
         private ToolStripMenuItem toolsSubItemsTitleFieldItem;
         private ToolStripMenuItem toolsSubItemsUpdateModifiedItem;
+        private ToolStripMenuItem toolsSubItemsUseGoogleAPI;
 
         public override bool Initialize(IPluginHost host)
         {
@@ -105,6 +106,9 @@ namespace YetAnotherFaviconDownloader
             toolsSubItemsUpdateModifiedItem = new ToolStripMenuItem("Update entry last modification time", null, LastModifiedMenu_Click);  // TODO: i18n?
             toolsSubItemsUpdateModifiedItem.Checked = Config.GetUpdateLastModified();
 
+            toolsSubItemsUseGoogleAPI = new ToolStripMenuItem("Use Google S2 API to fetch 16x16 icons", null, UseGoogleAPIMenu_Click);  // TODO: i18n?
+            toolsSubItemsUseGoogleAPI.Checked = Config.GetUseGoogleAPI();
+
             // Add Tools menu items
             toolsMenuSeparator = new ToolStripSeparator();
 
@@ -113,6 +117,7 @@ namespace YetAnotherFaviconDownloader
                 toolsSubItemsPrefixURLsItem,
                 toolsSubItemsTitleFieldItem,
                 toolsSubItemsUpdateModifiedItem,
+                toolsSubItemsUseGoogleAPI,
 #if DEBUG
                 new ToolStripMenuItem("Reset Icons", null, ResetIconsMenu_Click)
 #endif
@@ -214,6 +219,13 @@ namespace YetAnotherFaviconDownloader
             menu.Checked = !menu.Checked;
 
             Config.SetUpdateLastModified(menu.Checked);
+        }
+        private void UseGoogleAPIMenu_Click(object sender, EventArgs e) {
+            ToolStripMenuItem menu = sender as ToolStripMenuItem;
+
+            menu.Checked = !menu.Checked;
+
+            Config.SetUseGoogleAPI(menu.Checked);
         }
 
 #if DEBUG

--- a/plgx-build-install-run-loop.bat
+++ b/plgx-build-install-run-loop.bat
@@ -1,0 +1,32 @@
+:: Automatic UAC elevation script from https://stackoverflow.com/a/37669661/7024666
+
+NET SESSION
+IF %ERRORLEVEL% NEQ 0 GOTO ELEVATE
+GOTO ADMINTASKS
+
+:ELEVATE
+CD /d %~dp0
+MSHTA "javascript: var shell = new ActiveXObject('shell.application'); shell.ShellExecute('%~nx0', '', '', 'runas', 1);close();"
+EXIT
+
+:ADMINTASKS
+:: Change to script directory
+CD /d %~dp0
+
+:: Call build script
+call plgx-build.bat 1
+
+echo Installing...
+copy "%CD%\%NAME%.plgx" %KEEPASS%"\..\Plugins\%NAME%.plgx" /Y
+echo.
+
+echo Running KeePass...
+echo !NB! build-install-run will be executed again once KeePass is closed
+echo  - Change your code and compile before closing KeePass
+echo  - If this is not desired, close this window before closing KeePass
+%KEEPASS%
+
+:: After KeePass is closed, do build-install-run again 
+:: (useful only if the code has been changed and built before KeePass was closed)
+GOTO ADMINTASKS
+

--- a/plgx-build.bat
+++ b/plgx-build.bat
@@ -33,4 +33,5 @@ del "%SOURCE%\bin\Debug\%NAME%.*"
 copy "%CD%\%NAME%.plgx" "%SOURCE%\bin\Debug\%NAME%.plgx" /Y
 echo.
 
-pause
+if "%~1" == "" pause
+


### PR DESCRIPTION
### Changes

- Option in the Tools->YAFD menu to use Google S2 API to fetch icons. This returns an icon based on the domain name, so will likely return an incorrect icon if a sub-page has a different icon than at URI path `/` - but I did not test this.
- Always returns a 16x16 icon to keep DB size low.
- For debugging/testing: added `plgx-build-install-run-loop.bat` script to automatically install the plugin and run KeePass.

### Relevant issues
Fix #60, fix #57, fix #53, fix #52, fix #51, fix #50, fix #49, fix #47, fix #45, fix #44, fix #37, fix #21 

<img width="244" alt="clipboard" src="https://user-images.githubusercontent.com/55378880/135625108-442e1c76-638f-4298-a2a7-565efce90145.png">


Fixes partially #48, https://flightradar24.com/ works, but not https://www.flightradar24.com/

Partially implements #42 (16x16 icons only), but could also be done using the [Google S2 API](https://stackoverflow.com/questions/38599939/how-to-get-larger-favicon-from-googles-api/46044485).

Fixes partially maybe(?) #26, if the icon is the same as for the "domain" as given by Google.